### PR TITLE
Add basic backend and React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+client/node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # test-recharts
-create simple app which fetches rechart code from backend and renders on frontend
+
+This example demonstrates a simple full stack app that retrieves Recharts JSX snippets from MongoDB and renders them in the browser.
+
+## Setup
+
+1. **Install dependencies**
+
+   ```bash
+   # Backend
+   npm install express mongodb cors
+
+   # Frontend
+   cd client
+   npm install
+   ```
+
+2. **Run the backend**
+
+   ```bash
+   node server.js
+   ```
+
+3. **Run the frontend**
+
+   ```bash
+   cd client
+   npm start
+   ```
+
+The React app fetches a snippet from the `/api/snippet/:name` endpoint and displays it using `react-live`.

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-live": "^3.3.0",
+    "recharts": "^2.8.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Live Chart Renderer</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
+
+function App() {
+  const [snippet, setSnippet] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:4000/api/snippet/bar_chart_example')
+      .then(res => res.json())
+      .then(data => setSnippet(data.snippet));
+  }, []);
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h2>Live Chart Renderer</h2>
+      {snippet ? (
+        <LiveProvider code={snippet} scope={getScope()}>
+          <div style={{ display: 'flex', gap: 20 }}>
+            <div style={{ flex: 1 }}>
+              <h4>JSX Editor</h4>
+              <LiveEditor />
+              <LiveError />
+            </div>
+            <div style={{ flex: 1 }}>
+              <h4>Rendered Chart</h4>
+              <LivePreview />
+            </div>
+          </div>
+        </LiveProvider>
+      ) : (
+        <p>Loading snippet...</p>
+      )}
+    </div>
+  );
+}
+
+function getScope() {
+  const {
+    BarChart,
+    Bar,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer,
+  } = require('recharts');
+
+  return {
+    React,
+    ChartContainer: ({ data, chartType, config, height }) => (
+      <ResponsiveContainer width="100%" height={height}>
+        <BarChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey={config.xKey} />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey={config.yKey} fill={config.colors[0]} />
+        </BarChart>
+      </ResponsiveContainer>
+    ),
+  };
+}
+
+export default App;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/server.js
+++ b/server.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const { MongoClient } = require('mongodb');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+
+const uri = 'mongodb+srv://<username>:<password>@<cluster>.mongodb.net/?retryWrites=true&w=majority';
+const client = new MongoClient(uri);
+const dbName = 'codes';
+
+app.get('/api/snippet/:name', async (req, res) => {
+  try {
+    await client.connect();
+    const db = client.db(dbName);
+    const collection = db.collection('snippets');
+
+    const doc = await collection.findOne({ name: req.params.name });
+
+    if (!doc) {
+      return res.status(404).send({ error: 'Snippet not found' });
+    }
+
+    res.send({ snippet: doc.snippet });
+  } catch (error) {
+    console.error(error);
+    res.status(500).send({ error: 'Server error' });
+  }
+});
+
+app.listen(4000, () => {
+  console.log('Server running at http://localhost:4000');
+});


### PR DESCRIPTION
## Summary
- create Express server that fetches JSX chart snippets from MongoDB
- add React app that loads snippet via `react-live`
- document setup steps

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_687e92e3705c8321bfe5d8e5683f6018